### PR TITLE
Revert "Remove redundant `git add` from pkg-update.yml"

### DIFF
--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -59,9 +59,11 @@ jobs:
 
           git ls-tree -r --name-only "origin/$base" | grep -F Manifest.toml \
               | xargs git checkout "origin/$base" --
+          git ls-tree -r --name-only "origin/$base" | grep -F Manifest.toml \
+              | xargs git add -f --
 
       - run: git status
-      - run: git diff
+      - run: git diff --cached
 
       # https://github.com/tkf/julia-update-manifests
       - name: Update */Manifest.toml


### PR DESCRIPTION
Rollback a part of b559f30339cf1c3316f24de435c431119b6f7ad2.